### PR TITLE
Fixed dialog topics may not be displayed correctly when bHideDialogueMenu

### DIFF
--- a/Menus.cpp
+++ b/Menus.cpp
@@ -100,7 +100,7 @@ namespace Tralala
 		NextFrame_t NextFrame = (NextFrame_t)g_dialNextFrameAddr;
 
 		GFxMovieView* view = (Tralala::GFxMovieView*)menu->view;
-		if(!view || !Settings::bHideDialogueMenu)
+		if(!view || !g_zoom || !Settings::bHideDialogueMenu)
 			return NextFrame(menu, unk1, unk2);
 
 		GFxValue topicListHolder;
@@ -111,13 +111,22 @@ namespace Tralala
 
 			if (topicListHolder.GetDisplayInfo(&displayInfo))
 			{
+				/*
+				
+					Changes from:
+					https://github.com/derickso/AlternateConversationCamera/commit/884c59ab22652255f928f2f33fe61943e6f683e8
+
+				*/
 				
 				MenuTopicManager* mtm = MenuTopicManager::GetSingleton();
+				PlayerCamera* camera = PlayerCamera::GetSingleton();
 
-				GFxValue greetingState(0);
-				GFxValue topicShownState(1);
+				//GFxValue greetingState(0);
+				//GFxValue topicShownState(1);
 				GFxValue topicClickedState(2);		
 				GFxValue curState;
+
+				view->GetVariable(&curState, "_root.DialogueMenu_mc.eMenuState");
 
 				if (!g_zoom)
 				{
@@ -129,36 +138,28 @@ namespace Tralala
 					return NextFrame(menu, unk1, unk2);
 				}
 
-				view->GetVariable(&curState, "_root.DialogueMenu_mc.eMenuState");
-				PlayerCamera* camera = PlayerCamera::GetSingleton();
-
-				if (Settings::bSwitchTarget && (Settings::bForceThirdPerson || camera->IsCameraThirdPerson()))
+				if ((curState.GetType() == 3 && curState.data.number == 0) || (mtm->unk70 && !mtm->unkB9))
+				{
+					view->SetVariable("_root.DialogueMenu_mc.eMenuState", &topicClickedState, 0);
+					displayInfo.SetVisible(false);
+				}
+				else if (Settings::bSwitchTarget && (Settings::bForceThirdPerson || camera->IsCameraThirdPerson()))
 				{
 					if (camera->cameraRefHandle == PlayerRefHandle)
 					{
-						if (curState.GetType() == 3 && curState.data.number == 1)
-							view->SetVariable("_root.DialogueMenu_mc.eMenuState", &topicClickedState, 0);
-
 						displayInfo.SetVisible(false);
 					}		
-					else
+					else if (curState.GetType() == 3 && curState.data.number == 1)
 					{
-						view->SetVariable("_root.DialogueMenu_mc.eMenuState", &topicShownState, 0);
 						displayInfo.SetVisible(true);
 					}
 				}
 				else
 				{
 
-					if ((curState.GetType() == 3 && curState.data.number == 0) || (mtm->unk70 && !mtm->unkB9))
+					if (curState.GetType() == 3 && curState.data.number == 1)
 					{
-						view->SetVariable("_root.DialogueMenu_mc.eMenuState", &topicClickedState, 0);
-						displayInfo.SetVisible(false);
-					}
-					else
-					{
-						if (curState.GetType() == 3 && curState.data.number == 1)
-							displayInfo.SetVisible(true);
+						displayInfo.SetVisible(true);
 					}
 				}
 				


### PR DESCRIPTION
Hi,
from [mod page comments](https://www.nexusmods.com/skyrimspecialedition/mods/40722?tab=posts), I've been able to apply [this patch that fixes bHideDialogueMenu bug](https://github.com/derickso/AlternateConversationCamera/commit/884c59ab22652255f928f2f33fe61943e6f683e8) and successfully build the plugin.